### PR TITLE
Don't flicker posframe on self-insert.

### DIFF
--- a/eldoc-posframe.el
+++ b/eldoc-posframe.el
@@ -39,6 +39,11 @@
   :prefix "eldoc-posframe-"
   :group 'eldoc)
 
+(defcustom eldoc-posframe-display-at-point nil
+  "Display postframe at point."
+  :type 'boolean
+  :group 'eldoc-posframe)
+
 (defvar eldoc-posframe-buffer "*eldoc-posframe-buffer*"
   "The posframe buffer name use by eldoc-posframe.")
 
@@ -66,8 +71,8 @@
          :string (apply 'format format-string args)
          :background-color (face-background 'eldoc-posframe-background-face nil t)
          :internal-border-width 5
-         :left-fringe 10
-         :poshandler 'posframe-poshandler-frame-top-right-corner)
+         :left-fringe (unless eldoc-posframe-display-at-point 10)
+         :poshandler (unless eldoc-posframe-display-at-point 'posframe-poshandler-frame-top-right-corner))
         (dolist (hook eldoc-posframe-hide-posframe-hooks)
           (add-hook hook #'eldoc-posframe-maybe-hide-posframe nil t)))
     (eldoc-posframe-hide-posframe)))

--- a/eldoc-posframe.el
+++ b/eldoc-posframe.el
@@ -52,19 +52,25 @@
   (dolist (hook eldoc-posframe-hide-posframe-hooks)
     (remove-hook hook #'eldoc-posframe-hide-posframe t)))
 
+(defun eldoc-posframe-maybe-hide-posframe ()
+  "Hide messages if command was not a `self-insert-command'."
+  (unless (eq this-command 'self-insert-command)
+    (eldoc-posframe-hide-posframe)))
+
 (defun eldoc-posframe-show-posframe (format-string &rest args)
   "Display FORMAT-STRING and ARGS, using posframe.el library."
-  (eldoc-posframe-hide-posframe)
-  (when format-string
-    (posframe-show
-     eldoc-posframe-buffer
-     :string (apply 'format format-string args)
-     :background-color (face-background 'eldoc-posframe-background-face nil t)
-     :internal-border-width 5
-     :left-fringe 10
-     :poshandler 'posframe-poshandler-frame-top-right-corner)
-    (dolist (hook eldoc-posframe-hide-posframe-hooks)
-      (add-hook hook #'eldoc-posframe-hide-posframe nil t))))
+  (if format-string
+      (progn
+        (posframe-show
+         eldoc-posframe-buffer
+         :string (apply 'format format-string args)
+         :background-color (face-background 'eldoc-posframe-background-face nil t)
+         :internal-border-width 5
+         :left-fringe 10
+         :poshandler 'posframe-poshandler-frame-top-right-corner)
+        (dolist (hook eldoc-posframe-hide-posframe-hooks)
+          (add-hook hook #'eldoc-posframe-maybe-hide-posframe nil t)))
+    (eldoc-posframe-hide-posframe)))
 
 (defface eldoc-posframe-background-face
   '((t :inherit highlight))


### PR DESCRIPTION
This adds a check to the clean-up hook that only hides the posframe if
it was not a `self-insert-command`.

I would like to also skip the hide if commands are any movement or edit
commands. Or potentially if the line is still the same, so those
operations wouldn't also flicker the frame. This is more along the lines
of the original ElDoc displayed in message.