### PR TITLE
Make tooltip behaviour and look configurable

### DIFF
--- a/eldoc-posframe.el
+++ b/eldoc-posframe.el
@@ -39,6 +39,21 @@
   :prefix "eldoc-posframe-"
   :group 'eldoc)
 
+(defcustom eldoc-posframe-padding 5
+  "Padding inside the tooltips."
+  :type 'integer
+  :group 'eldoc-posframe)
+
+(defcustom eldoc-posframe-left-fringe 10
+  "Fringe on the left side."
+  :type 'integer
+  :group 'eldoc-posframe)
+
+(defcustom eldoc-posframe-poshandler #'posframe-poshandler-frame-top-right-corner
+  "Display postframe at point."
+  :type 'function
+  :group 'eldoc-posframe)
+
 (defvar eldoc-posframe-buffer "*eldoc-posframe-buffer*"
   "The posframe buffer name use by eldoc-posframe.")
 
@@ -65,9 +80,9 @@
          eldoc-posframe-buffer
          :string (apply 'format format-string args)
          :background-color (face-background 'eldoc-posframe-background-face nil t)
-         :internal-border-width 5
-         :left-fringe 10
-         :poshandler 'posframe-poshandler-frame-top-right-corner)
+         :internal-border-width eldoc-posframe-padding
+         :left-fringe eldoc-posframe-left-fringe
+         :poshandler eldoc-posframe-poshandler)
         (dolist (hook eldoc-posframe-hide-posframe-hooks)
           (add-hook hook #'eldoc-posframe-maybe-hide-posframe nil t)))
     (eldoc-posframe-hide-posframe)))

--- a/eldoc-posframe.el
+++ b/eldoc-posframe.el
@@ -52,19 +52,25 @@
   (dolist (hook eldoc-posframe-hide-posframe-hooks)
     (remove-hook hook #'eldoc-posframe-hide-posframe t)))
 
+(defun eldoc-posframe-maybe-hide-posframe ()
+  "Hide messages if command was not a `self-insert-command'."
+  (unless (eq this-command 'self-insert-command)
+    (eldoc-posframe-hide-posframe)))
+
 (defun eldoc-posframe-show-posframe (format-string &rest args)
   "Display FORMAT-STRING and ARGS, using posframe.el library."
-  (eldoc-posframe-hide-posframe)
-  (when format-string
-    (posframe-show
-     eldoc-posframe-buffer
-     :string (apply 'format format-string args)
-     :background-color (face-background 'eldoc-posframe-background-face nil t)
-     :internal-border-width 5
-     :left-fringe 10
-     :poshandler 'posframe-poshandler-frame-top-right-corner)
-    (dolist (hook eldoc-posframe-hide-posframe-hooks)
-      (add-hook hook #'eldoc-posframe-hide-posframe nil t))))
+  (if format-string
+      (progn
+        (posframe-show
+         eldoc-posframe-buffer
+         :string (apply 'format format-string args)
+         :background-color (face-background 'eldoc-posframe-background-face nil t)
+         :internal-border-width 5
+         :left-fringe 10
+         :poshandler 'posframe-poshandler-frame-top-right-corner)
+        (dolist (hook eldoc-posframe-hide-posframe-hooks)
+          (add-hook hook #'eldoc-posframe-maybe-hide-posframe nil t)))
+    (eldoc-posframe-hide-posframe)))
 
 (defface eldoc-posframe-background-face
   '((t :inherit highlight))


### PR DESCRIPTION
Add possibility to configure the poshandler, to set the position of the
tooltip, e.g.
- posframe-poshandler-frame-top-right-corner
- posframe-poshandler-point-bottom-left-corner
- posframe-poshandler-point-top-left-corner

Also make fringe width configurable and the padding (internal-border-width).

As this is based on top of the other PR #2 both commits appear here.